### PR TITLE
feat: jsdoc improvement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!--
+Thank you for your pull request. Please review below requirements.
+Bug fixes and new features should include tests and possibly benchmarks.
+Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
+
+感谢您贡献代码。请确认下列 checklist 的完成情况。
+Bug 修复和新功能必须包含测试，必要时请附上性能测试。
+Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
+-->
+
+##### Checklist
+<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
+
+- [ ] `npm test` passes
+- [ ] tests and/or benchmarks are included
+- [ ] documentation is changed or added
+- [ ] commit message follows commit guidelines
+
+##### Affected core subsystem(s)
+<!-- Provide affected core subsystem(s). -->
+
+
+##### Description of change
+<!-- Provide a description of the change below this comment. -->

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 /npm-debug.log
+.vscode/
+yarn.lock
+*.log

--- a/lib/legacy.js
+++ b/lib/legacy.js
@@ -8,6 +8,7 @@ module.exports = {
     './rules/style',
     './rules/node',
     './rules/errors',
+    './rules/jsdoc',
   ].map(require.resolve),
   env: {
     amd: false,

--- a/lib/rules/errors.js
+++ b/lib/rules/errors.js
@@ -199,15 +199,11 @@ module.exports = {
     'use-isnan': 'error',
 
     /**
+     * This rule has deprecated https://eslint.org/blog/2018/11/jsdoc-end-of-life
      * ensure JSDoc comments are valid
      * @see http://eslint.org/docs/rules/valid-jsdoc
      */
-    'valid-jsdoc': [ 'error', {
-      prefer: {
-        returns: 'return',
-      },
-      requireReturn: false,
-    }],
+    'valid-jsdoc': 'off',
 
     /**
      * Doesn't enforce comparing typeof expressions against valid strings

--- a/lib/rules/jsdoc.js
+++ b/lib/rules/jsdoc.js
@@ -1,0 +1,123 @@
+'use strict';
+
+module.exports = {
+  plugins: [ 'jsdoc' ],
+  settings: {
+    jsdoc: { tagNamePreference: { returns: 'return' } },
+  },
+  rules: {
+    /**
+     * Ensures that (JavaScript) examples within JSDoc adhere to ESLint rules.
+     * @see https://github.com/gajus/eslint-plugin-jsdoc#check-examples
+     */
+    'jsdoc/check-examples': 1,
+
+    /**
+     * Ensures that parameter names in JSDoc match those in the function declaration.
+     * @see https://github.com/gajus/eslint-plugin-jsdoc#check-param-names
+     */
+    'jsdoc/check-param-names': 1,
+
+    /**
+     * Reports invalid block tag names.
+     * @see https://github.com/gajus/eslint-plugin-jsdoc#check-tag-names
+     */
+    'jsdoc/check-tag-names': 1,
+
+    /**
+     * Reports invalid types.
+     * @see https://github.com/gajus/eslint-plugin-jsdoc#check-types
+     */
+    'jsdoc/check-types': 'off',
+
+    /**
+     * Enforces a consistent padding of the block description.
+     * @see https://github.com/gajus/eslint-plugin-jsdoc#newline-after-description
+     */
+    'jsdoc/newline-after-description': 'off',
+
+    /**
+     * Checks that types in jsdoc comments are defined. This can be used to check unimported types.
+     * @see https://github.com/gajus/eslint-plugin-jsdoc#no-undefined-types
+     */
+    'jsdoc/no-undefined-types': 'off',
+
+    /**
+     * Requires that all functions have a description.
+     * @see https://github.com/gajus/eslint-plugin-jsdoc#require-description
+     */
+    'jsdoc/require-description': 'off',
+
+    /**
+     * Requires that block description and tag description are written in complete sentences
+     * @see https://github.com/gajus/eslint-plugin-jsdoc#require-description-complete-sentence
+     */
+    'jsdoc/require-description-complete-sentence': 'off',
+
+    /**
+     * Requires that all functions have examples.
+     * @see https://github.com/gajus/eslint-plugin-jsdoc#require-example
+     */
+    'jsdoc/require-example': 'off',
+
+    /**
+     * Requires a hyphen before the @param description.
+     * @see https://github.com/gajus/eslint-plugin-jsdoc#require-hyphen-before-param-description
+     */
+    'jsdoc/require-hyphen-before-param-description': 'off',
+
+    /**
+     * Requires that all function parameters are documented.
+     * @see https://github.com/gajus/eslint-plugin-jsdoc#require-param
+     */
+    'jsdoc/require-param': 1,
+
+    /**
+     * Requires that @param tag has description value.
+     * @see https://github.com/gajus/eslint-plugin-jsdoc#require-param-description
+     */
+    'jsdoc/require-param-description': 1,
+
+    /**
+     * Requires that all function parameters have name.
+     * @see https://github.com/gajus/eslint-plugin-jsdoc#require-param-name
+     */
+    'jsdoc/require-param-name': 1,
+
+    /**
+     * Requires that @param tag has type value.
+     * @see https://github.com/gajus/eslint-plugin-jsdoc#require-param-type
+     */
+    'jsdoc/require-param-type': 1,
+
+    /**
+     * Requires returns are documented.
+     * @see https://github.com/gajus/eslint-plugin-jsdoc#require-returns
+     */
+    'jsdoc/require-returns': 'off',
+
+    /**
+     * Checks if the return expression exists in function body and in the comment.
+     * @see https://github.com/gajus/eslint-plugin-jsdoc#require-returns-check
+     */
+    'jsdoc/require-returns-check': 1,
+
+    /**
+     * Requires that @returns tag has description value.
+     * @see https://github.com/gajus/eslint-plugin-jsdoc#require-returns-description
+     */
+    'jsdoc/require-returns-description': 1,
+
+    /**
+     * Requires that @returns tag has type value.
+     * @see https://github.com/gajus/eslint-plugin-jsdoc#require-returns-type
+     */
+    'jsdoc/require-returns-type': 1,
+
+    /**
+     * Requires all types to be valid JSDoc or Closure compiler types without syntax errors.
+     * @see https://github.com/gajus/eslint-plugin-jsdoc#valid-types
+     */
+    'jsdoc/valid-types': 'off',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "babel-eslint": "^8.2.6",
     "eslint-plugin-eggache": "^1.0.0",
     "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-jsdoc": "^4.1.1",
     "eslint-plugin-jsx-a11y": "^6.1.1",
     "eslint-plugin-react": "^7.11.1"
   },

--- a/test/fixtures/jsdoc-app/index.js
+++ b/test/fixtures/jsdoc-app/index.js
@@ -1,0 +1,43 @@
+'use strict';
+
+/**
+ * @return {Number} value
+ */
+exports.myFn = function myFn(abc) {
+  return abc;
+};
+
+/**
+ */
+exports.myFn2 = function myFn2() {
+  return 123;
+};
+
+/**
+ * @return {Number}
+ */
+exports.myFn3 = function myFn3() {
+  return 123;
+};
+
+// support complex type
+
+class MyTest {
+  test() {}
+}
+
+exports.MyTest = MyTest;
+
+/** @type {(this: MyTest)=>number} */
+exports.myFn4 = function myFn4() {
+  this.test();
+  return 123;
+};
+
+/**
+ * @param {Number} a
+ * @param {Number} b
+ */
+exports.myFn5 = function myFn5(a, b) {
+  return a + b;
+};

--- a/test/jsdoc.test.js
+++ b/test/jsdoc.test.js
@@ -6,16 +6,14 @@ const coffee = require('coffee');
 describe('test/jsdoc.test.js', () => {
   const cwd = path.join(__dirname, 'fixtures/jsdoc-app');
 
-  describe('comma dangle', () => {
-    it('should warnning when function params is not exist', () => {
-      return coffee.spawn('eslint', [ 'index.js' ], { cwd })
-        // .debug()
-        .expect('stdout', /warning {2}Missing JSDoc @param "abc" declaration/)
-        .expect('stdout', /warning {2}Missing JSDoc @return description/)
-        .expect('stdout', /warning {2}Missing JSDoc @param "a" description/)
-        .expect('stdout', /warning {2}Missing JSDoc @param "b" description/)
-        .expect('code', 0)
-        .end();
-    });
+  it('should warnning when function params is not exist', () => {
+    return coffee.spawn('eslint', [ 'index.js' ], { cwd })
+      // .debug()
+      .expect('stdout', /warning {2}Missing JSDoc @param "abc" declaration/)
+      .expect('stdout', /warning {2}Missing JSDoc @return description/)
+      .expect('stdout', /warning {2}Missing JSDoc @param "a" description/)
+      .expect('stdout', /warning {2}Missing JSDoc @param "b" description/)
+      .expect('code', 0)
+      .end();
   });
 });

--- a/test/jsdoc.test.js
+++ b/test/jsdoc.test.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const path = require('path');
+const coffee = require('coffee');
+
+describe('test/jsdoc.test.js', () => {
+  const cwd = path.join(__dirname, 'fixtures/jsdoc-app');
+
+  describe('comma dangle', () => {
+    it('should warnning when function params is not exist', () => {
+      return coffee.spawn('eslint', [ 'index.js' ], { cwd })
+        // .debug()
+        .expect('stdout', /warning {2}Missing JSDoc @param "abc" declaration/)
+        .expect('stdout', /warning {2}Missing JSDoc @return description/)
+        .expect('stdout', /warning {2}Missing JSDoc @param "a" description/)
+        .expect('stdout', /warning {2}Missing JSDoc @param "b" description/)
+        .expect('code', 0)
+        .end();
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

ESLint 内置的 JSdoc 规则已经被官方弃用了：https://eslint.org/blog/2018/11/jsdoc-end-of-life  ，[官方推荐](https://github.com/eslint/eslint/issues/10257#issuecomment-442525923)使用 [eslint-plugin-jsdoc](https://github.com/gajus/eslint-plugin-jsdoc)  ，因此对 jsdoc 规则做了迁移，为了保证兼容性，将相关规则改成 warnning
