### PR TITLE
fix: no need to lint empty interface and params

### DIFF
--- a/lib/rules/typescript.js
+++ b/lib/rules/typescript.js
@@ -8,11 +8,19 @@ module.exports = {
   extends: [ 'plugin:@typescript-eslint/recommended' ],
 
   rules: {
+    'jsdoc/require-param': 'off',
+    'jsdoc/require-param-type': 'off',
     'comma-dangle': [ 'error', 'always-multiline' ],
     'spaced-comment': [ 'error', 'always', {
       exceptions: [ '-', '+' ],
       markers: [ '*!', '/' ],
     }],
+
+    /**
+     * An empty interface is equivalent to its supertype
+     * @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-empty-interface.md
+     */
+    '@typescript-eslint/no-empty-interface': 'off',
 
     /**
      * Variables that are declared and not used anywhere in the code are most likely an error due to incomplete refactoring


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

新增几个不需要开启的规则。因为 ts 本身有声明，所以对 jsdoc 的约束可以不用那么严格。以及允许空的 interface 存在（ 跟 tslint-config-egg 一致 ）
