### PR TITLE
fix: unused vars rule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - '8'
   - '10'
   - '12'
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-    - nodejs_version: '8'
     - nodejs_version: '10'
     - nodejs_version: '12'
 

--- a/lib/rules/typescript.js
+++ b/lib/rules/typescript.js
@@ -28,9 +28,8 @@ module.exports = {
      */
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': [ 'error', {
-      vars: 'all',
+      vars: 'local',
       args: 'after-used',
-      ignoreRestSiblings: false,
     }],
 
     /**

--- a/lib/rules/typescript.js
+++ b/lib/rules/typescript.js
@@ -27,7 +27,11 @@ module.exports = {
      * @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md
      */
     'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': [ 'error', {
+      vars: 'all',
+      args: 'after-used',
+      ignoreRestSiblings: false,
+    }],
 
     /**
      * Enforce camelCase naming convention

--- a/lib/rules/typescript.js
+++ b/lib/rules/typescript.js
@@ -26,6 +26,7 @@ module.exports = {
      * Variables that are declared and not used anywhere in the code are most likely an error due to incomplete refactoring
      * @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md
      */
+    'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': 'off',
 
     /**

--- a/test/fixtures/ts-app/align/arguments.ts
+++ b/test/fixtures/ts-app/align/arguments.ts
@@ -1,3 +1,3 @@
 setTimeout(() => {
-
+  console.log('');
 }, 200);

--- a/test/fixtures/ts-app/align/elements.ts
+++ b/test/fixtures/ts-app/align/elements.ts
@@ -1,4 +1,4 @@
-const foo = [
+export const foo = [
   1,
   2,
 ];

--- a/test/fixtures/ts-app/align/parameters-error.ts
+++ b/test/fixtures/ts-app/align/parameters-error.ts
@@ -1,4 +1,8 @@
 function bar(
   a: string,
    b: string
-) {}
+) {
+  console.log(a, b);
+}
+
+export { bar };

--- a/test/fixtures/ts-app/align/parameters.ts
+++ b/test/fixtures/ts-app/align/parameters.ts
@@ -4,3 +4,5 @@ function bar(
 ) {
   console.info(a, b);
 }
+
+export { bar };

--- a/test/fixtures/ts-app/align/statements.ts
+++ b/test/fixtures/ts-app/align/statements.ts
@@ -1,2 +1,4 @@
 const foo1 = 1;
 const bar1 = 2;
+
+export { foo1, bar1 };

--- a/test/fixtures/ts-app/comma/trailing-comma.ts
+++ b/test/fixtures/ts-app/comma/trailing-comma.ts
@@ -15,12 +15,4 @@ function foo2(
   console.info(a + b);
 }
 
-import {
-  a,
-  b,
-} from 'egg';
-
-export {
-  a,
-  b,
-} from 'egg';
+export { foo2 };

--- a/test/fixtures/ts-app/comma/trailing-comma.ts
+++ b/test/fixtures/ts-app/comma/trailing-comma.ts
@@ -15,4 +15,13 @@ function foo2(
   console.info(a + b);
 }
 
-export { foo2 };
+import {
+  fork,
+  spawn,
+} from 'coffee';
+
+export {
+  Rule,
+} from 'coffee';
+
+export { foo2, fork, spawn };

--- a/test/fixtures/ts-app/reference/unused-vars.ts
+++ b/test/fixtures/ts-app/reference/unused-vars.ts
@@ -1,0 +1,1 @@
+import { abc } from './semi/semi';

--- a/test/ts.test.js
+++ b/test/ts.test.js
@@ -151,5 +151,12 @@ describe('test/ts.test.js', () => {
         .expect('code', 0)
         .end();
     });
+
+    it('should success with unused variables', () => {
+      return coffee.spawn('eslint', [ './reference/unused-vars.ts' ], { cwd })
+        // .debug()
+        .expect('code', 0)
+        .end();
+    });
   });
 });

--- a/test/ts.test.js
+++ b/test/ts.test.js
@@ -155,7 +155,7 @@ describe('test/ts.test.js', () => {
     it('should success with unused variables', () => {
       return coffee.spawn('eslint', [ './reference/unused-vars.ts' ], { cwd })
         // .debug()
-        .expect('code', 0)
+        .expect('code', 1)
         .end();
     });
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x ] `npm test` passes
- [ x ] tests and/or benchmarks are included
- [ x ] documentation is changed or added
- [ x ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

add `no-unused-vars` rule which is prerequisite for rule `@typescript-eslint/no-unused-vars`.
New test case is included, CI config updated.