### PR TITLE
Update typescript.js

### DIFF
--- a/lib/rules/typescript.js
+++ b/lib/rules/typescript.js
@@ -21,8 +21,8 @@ module.exports = {
       'error',
       {
         types: {
-          '{}': false,
-          object: false,
+          '{}': null,
+          object: null,
         },
         extendDefaults: true,
       },


### PR DESCRIPTION
	Configuration for rule "@typescript-eslint/ban-types" is invalid:
	Value false should be null.
	Value false should be string.
	Value false should be object.
	Value false should match exactly one schema in oneOf.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
