### PR TITLE
feat: avoid @typescript-eslint/typescript-estree warning message

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,8 +17,6 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "master" ]
-  schedule:
-    - cron: '33 21 * * 5'
 
 jobs:
   analyze:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,4 +13,4 @@ jobs:
     uses: node-modules/github-actions/.github/workflows/node-test.yml@master
     with:
       os: 'ubuntu-latest'
-      version: '14, 16, 18, 29'
+      version: '14, 16, 18, 20'

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,12 +7,10 @@ on:
   pull_request:
     branches: [ master ]
 
-  workflow_dispatch: {}
-
 jobs:
   Job:
     name: Node.js
-    uses: artusjs/github-actions/.github/workflows/node-test.yml@v1
+    uses: node-modules/github-actions/.github/workflows/node-test.yml@master
     with:
       os: 'ubuntu-latest'
-      version: '14, 16, 18'
+      version: '14, 16, 18, 29'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,10 @@ on:
   push:
     branches: [ master ]
 
-  workflow_dispatch: {}
-
 jobs:
   release:
     name: Node.js
-    uses: artusjs/github-actions/.github/workflows/node-release.yml@v1
+    uses: node-modules/github-actions/.github/workflows/node-release.yml@master
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GIT_TOKEN: ${{ secrets.GIT_TOKEN }}

--- a/lib/legacy.js
+++ b/lib/legacy.js
@@ -1,5 +1,3 @@
-'use strict';
-
 module.exports = {
   extends: [
     './rules/best-practices',

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "dependencies": {
     "@babel/core": "^7.16.0",
     "@babel/eslint-parser": "^7.16.3",
-    "@typescript-eslint/eslint-plugin": "^5.4.0",
-    "@typescript-eslint/parser": "^5.4.0",
+    "@typescript-eslint/eslint-plugin": "^6.7.0",
+    "@typescript-eslint/parser": "^6.7.0",
     "eslint-plugin-eggache": "^2.0.0",
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-jsdoc": "^39.3.0",
@@ -29,7 +29,7 @@
     "egg-bin": "6",
     "eslint": "^8.3.0",
     "git-contributor": "2",
-    "typescript": "^4.5.2"
+    "typescript": "^5.2.2"
   },
   "repository": {
     "type": "git",

--- a/test/fixtures/ts-app/constructor/correct.ts
+++ b/test/fixtures/ts-app/constructor/correct.ts
@@ -2,5 +2,7 @@ export class MyClass {
   constructor(
     public a: number,
     public b: string,
-  ) {}
+  ) {
+    // ignore
+  }
 }

--- a/test/ts.test.js
+++ b/test/ts.test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const path = require('path');
 const coffee = require('coffee');
 
@@ -163,7 +161,7 @@ describe('test/ts.test.js', () => {
   describe('no-useless-constructor', () => {
     it('should success', () => {
       return coffee.spawn('eslint', [ './constructor/correct.ts' ], { cwd })
-        // .debug()
+        .debug()
         .expect('code', 0)
         .end();
     });

--- a/typescript.js
+++ b/typescript.js
@@ -1,5 +1,3 @@
-'use strict';
-
 module.exports = {
   parser: '@typescript-eslint/parser',
   plugins: [ '@typescript-eslint' ],


### PR DESCRIPTION
```
WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=3.3.1 <5.2.0

YOUR TYPESCRIPT VERSION: 5.2.2

Please only submit bug reports when using the officially supported version.
```
